### PR TITLE
Calendar is now caching requests

### DIFF
--- a/lib/model/calendar_event.dart
+++ b/lib/model/calendar_event.dart
@@ -28,4 +28,16 @@ class CalendarEvent {
         className: json['className'] as String? ?? ''
     );
   }
+
+  Map<String, dynamic> toJSON() {
+    return {
+      'id': id,
+      'title': title,
+      'start': start.toString(),
+      'end': end.toString(),
+      'allDay': allDay,
+      'editable': editable,
+      'className': className
+    };
+  }
 }


### PR DESCRIPTION
In order to avoid the first request to be 3 seconds long, calendar now implements the cache (previously implemented only in login page). This is made by using files and a potential improvement would be to use a local no-sql database such as hive.