### PR TITLE
Enhanced absences screen

### DIFF
--- a/lib/main_handler.dart
+++ b/lib/main_handler.dart
@@ -1,6 +1,6 @@
 import 'package:ent/screens/calendar_screen.dart';
 import 'package:ent/screens/home_screen.dart';
-import 'package:ent/screens/absence_screen.dart';
+import 'package:ent/screens/absences/absence_screen.dart';
 import 'package:ent/screens/notes/note_screen.dart';
 import 'package:ent/screens/settings_screen.dart';
 import 'package:flutter/material.dart';

--- a/lib/screens/absences/absence_list.dart
+++ b/lib/screens/absences/absence_list.dart
@@ -1,0 +1,71 @@
+import 'package:auto_size_text/auto_size_text.dart';
+import 'package:flutter/material.dart';
+
+import '../../model/absences.dart';
+import '../../widgets/custom_card_list.dart';
+
+class AbsenceList extends StatelessWidget {
+  const AbsenceList({super.key, required this.absences});
+
+  final List<Absence> absences;
+
+  Color defineAbsenceColor(Absence absence) {
+    return absence.reason.toLowerCase().contains("justifiée") ? Colors.green :
+            absence.reason.toLowerCase().contains("non excusée") ? Colors.red :
+            Colors.lightGreen;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (absences.isEmpty) {
+      return Center(
+          child: Text("Aucune absence enregistrée", style: Theme.of(context).textTheme.bodyLarge)
+      );
+    }
+
+    return ListView.builder(
+      itemCount: absences.length,
+      itemBuilder: (context, index) {
+        Absence absence = absences[index];
+        return CustomCardList(
+          constraints: BoxConstraints(maxHeight: 110),
+          leadingColor: defineAbsenceColor(absence),
+          leading: Text(
+            absence.date.substring(0, absence.date.lastIndexOf("/")),
+            style: TextStyle(
+                fontSize: 14.0,
+                fontWeight: FontWeight.bold,
+                color: Colors.black),
+          ),
+          title: AutoSizeText(
+            absence.course,
+            style: TextStyle(fontSize: 20.0,fontWeight:FontWeight.bold),
+            overflow: TextOverflow.ellipsis,
+            maxLines: 1,
+          ),
+          subtitle: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                absence.hours.replaceAll(":", "h"),
+                style: TextStyle(
+                    fontSize: 14.0, color: Color(0xFF555555)),
+              ),
+              Text(
+                absence.reason,
+                style: TextStyle(
+                    fontSize: 14.0, color: defineAbsenceColor(absence)),
+              )
+            ]
+          ),
+          trailing: Text(
+            absence.duration.replaceAll(":", "h"),
+            style: TextStyle(
+                fontSize: 24.0, fontWeight: FontWeight.bold, color: defineAbsenceColor(absence)),
+          ),
+          onTap: () {  },
+        );
+      },
+    );
+  }
+}

--- a/lib/screens/absences/absence_screen.dart
+++ b/lib/screens/absences/absence_screen.dart
@@ -1,10 +1,9 @@
-import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 
-import '../model/absences.dart';
-import '../services/api_service.dart';
-import '../services/token_service.dart';
-import '../widgets/custom_card_list.dart';
+import '../../model/absences.dart';
+import '../../services/api_service.dart';
+import '../../services/token_service.dart';
+import 'absence_list.dart';
 
 
 class AbsenceView extends StatefulWidget {
@@ -153,56 +152,6 @@ class _AbsenceViewState extends State<AbsenceView> {
           },
         ),
       ),
-    );
-  }
-}
-
-class AbsenceList extends StatelessWidget {
-  const AbsenceList({super.key, required this.absences});
-
-  final List<Absence> absences;
-
-  @override
-  Widget build(BuildContext context) {
-    if (absences.isEmpty) {
-      return Center(
-          child: Text("Aucune absence enregistrée", style: Theme.of(context).textTheme.bodyLarge)
-      );
-    }
-
-    return ListView.builder(
-      itemCount: absences.length,
-      itemBuilder: (context, index) {
-        Absence absence = absences[index];
-        return CustomCardList(
-            constraints: BoxConstraints(maxHeight: 100),
-            leadingColor: Colors.purple,
-            leading: Text(
-              absence.date,
-              style: TextStyle(
-                  fontSize: 14.0,
-                  fontWeight: FontWeight.bold,
-                  color: Colors.black),
-            ),
-            title: AutoSizeText(
-              absence.course,
-              style: TextStyle(fontSize: 20.0,fontWeight:FontWeight.bold),
-              overflow: TextOverflow.ellipsis,
-              maxLines: 1,
-            ),
-            subtitle: Text(
-              absence.teachers.join(", "),
-              style: TextStyle(
-                  fontSize: 14.0, color: Colors.grey[700]),
-            ),
-            trailing: Text(
-              absence.duration,
-              style: TextStyle(
-                  fontSize: 24.0, fontWeight: FontWeight.bold),
-            ),
-            onTap: () {  },
-        );
-      },
     );
   }
 }

--- a/lib/screens/absences/absence_screen.dart
+++ b/lib/screens/absences/absence_screen.dart
@@ -1,8 +1,10 @@
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 
 import '../model/absences.dart';
 import '../services/api_service.dart';
 import '../services/token_service.dart';
+import '../widgets/custom_card_list.dart';
 
 
 class AbsenceView extends StatefulWidget {
@@ -172,71 +174,33 @@ class AbsenceList extends StatelessWidget {
       itemCount: absences.length,
       itemBuilder: (context, index) {
         Absence absence = absences[index];
-        return Container(
-            decoration: const BoxDecoration(
-                border: Border(top: BorderSide(), bottom: BorderSide())
+        return CustomCardList(
+            constraints: BoxConstraints(maxHeight: 100),
+            leadingColor: Colors.purple,
+            leading: Text(
+              absence.date,
+              style: TextStyle(
+                  fontSize: 14.0,
+                  fontWeight: FontWeight.bold,
+                  color: Colors.black),
             ),
-            child: ListTile(
-                subtitle: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceAround,
-                  children: [
-                    SizedBox(
-                        width: MediaQuery.of(context).size.width/3.5,
-                        child: Column(
-                          children: [
-                            Icon(
-                                Icons.description,
-                                size: 48,
-                                color: absence.reason.contains("justifiée") ? Colors.green :
-                                absence.reason.contains("non excusée") ? Colors.red :
-                                Colors.lightGreen
-                            ),
-                            const Text("Absence"),
-                            Text(
-                                absence.reason.replaceAll("Absence ", ""),
-                                style: TextStyle(
-                                    color: absence.reason.contains("justifiée") ? Colors.green :
-                                    absence.reason.contains("non excusée") ? Colors.red :
-                                    Colors.lightGreen,
-                                    fontSize: 16
-                                )
-                            )
-                          ],
-                        )
-                    ),
-                    Expanded(
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Row(
-                                children: [
-                                  Icon(Icons.calendar_month),
-                                  Text(absence.date)
-                                ]
-                            ),
-                            Row(
-                                children: [
-                                  Icon(Icons.timer),
-                                  Text(absence.hours)
-                                ]
-                            ),
-                            Row(
-                                children: [
-                                  Icon(Icons.person),
-                                  Text(absence.teachers.join(", "))
-                                ]
-                            ),
-                            Row(
-                                children: [
-                                  Icon(Icons.subject),
-                                  Text(absence.subject)
-                                ]
-                            ),
-                          ],
-                        ))
-                  ],
-                )
-            )
+            title: AutoSizeText(
+              absence.course,
+              style: TextStyle(fontSize: 20.0,fontWeight:FontWeight.bold),
+              overflow: TextOverflow.ellipsis,
+              maxLines: 1,
+            ),
+            subtitle: Text(
+              absence.teachers.join(", "),
+              style: TextStyle(
+                  fontSize: 14.0, color: Colors.grey[700]),
+            ),
+            trailing: Text(
+              absence.duration,
+              style: TextStyle(
+                  fontSize: 24.0, fontWeight: FontWeight.bold),
+            ),
+            onTap: () {  },
         );
       },
     );

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -3,7 +3,7 @@ import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'calendar_screen.dart';
 import '../model/absences.dart';
-import 'absence_screen.dart';
+import 'absences/absence_screen.dart';
 import '../services/User_service.dart';
 import '../services/calendar_service.dart';
 import '../model/notation.dart';

--- a/lib/widgets/custom_card_list.dart
+++ b/lib/widgets/custom_card_list.dart
@@ -37,7 +37,7 @@ class CustomCardList extends StatelessWidget {
           margin: EdgeInsets.symmetric(horizontal: 8.0),
           decoration: BoxDecoration(
             color: boxColor,
-            border: Border(left: BorderSide(color: Colors.purple, width: 5)),
+            border: Border(left: BorderSide(color: leadingColor, width: 5)),
             borderRadius: BorderRadius.circular(8.0),
             boxShadow: [
               BoxShadow(

--- a/lib/widgets/hamburger_menu.dart
+++ b/lib/widgets/hamburger_menu.dart
@@ -5,7 +5,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../screens/calendar_screen.dart';
-import '../screens/absence_screen.dart';
+import '../screens/absences/absence_screen.dart';
 import '../screens/notes/note_screen.dart';
 
 class HamburgerMenu extends StatelessWidget {


### PR DESCRIPTION
This PR adds the enhanced absences screen using the widget from notations.
This screen misses cache however and could not be tested with true absences, only the ones in English provided by the fake token of the API.